### PR TITLE
Fix: Images are copied to the root folder if a plug-in creates the images in another directory.

### DIFF
--- a/src/ImageminWebpackPlugin.js
+++ b/src/ImageminWebpackPlugin.js
@@ -186,7 +186,7 @@ class ImageminWebpackPlugin {
                     });
                   }
 
-                  const interpolatedName = interpolateName(file, name, {
+                  const interpolatedName = interpolateName(file, path.join(path.dirname(file), name), {
                     content: source.source()
                   });
 


### PR DESCRIPTION
This pull request keeps the path of where the image is copied too.