### PR TITLE
Refactor code

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,33 +453,6 @@ module.exports = {
 };
 ```
 
-#### `manifest`
-
-Contain optimized list of images from other plugins.
-
-Note: contains only assets compressed by plugin.
-Note: manifest will be contain list of optimized images only after `emit` event.
-
-**webpack.config.js**
-
-```js
-const ImageminPlugin = require("imagemin-webpack");
-const ManifestPlugin = require("manifest-webpack-plugin");
-const manifest = {};
-
-module.exports = {
-  plugins: [
-    new ImageminPlugin({
-      manifest,
-    }),
-    new ManifestPlugin({
-      // Contain compressed images
-      manifest,
-    }),
-  ],
-};
-```
-
 ### Loader Options
 
 |         Name          |        Type         |         Default         | Description                                 |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ module.exports = {
       {
         loader: "file-loader",
         options: {
-          emitFile: true, // Don't forget emit images
           name: "[path][name].[ext]",
         },
         test: /\.(jpe?g|png|gif|svg)$/i,
@@ -226,7 +225,6 @@ module.exports = {
 | **`imageminOptions`** |                `{Object}`                 |             `{ plugins: [] }`              | Options for `imagemin`                                                                                                    |
 |     **`loader`**      |                `{Boolean}`                |                   `true`                   | Automatically adding `imagemin-loader` (require for minification images using in `url-loader`, `svg-url-loader` or other) |
 | **`maxConcurrency`**  |                `{Number}`                 |    `Math.max(1, os.cpus().length - 1)`     | Maximum number of concurrency optimization processes in one time                                                          |
-|      **`name`**       |                `{String}`                 |               `[hash].[ext]`               | The target asset name                                                                                                     |
 |    **`manifest`**     |                `{Object}`                 |                `undefined`                 | Contain optimized list of images from other plugins                                                                       |
 
 <!--lint enable no-html-->
@@ -430,24 +428,6 @@ module.exports = {
   plugins: [
     new ImageminPlugin({
       maxConcurrency: 3,
-    }),
-  ],
-};
-```
-
-#### `name`
-
-The target asset name.
-
-**webpack.config.js**
-
-```js
-const ImageminPlugin = require("imagemin-webpack");
-
-module.exports = {
-  plugins: [
-    new ImageminPlugin({
-      name: "[hash]-compressed.[ext]",
     }),
   ],
 };

--- a/__tests__/ImageminPlugin.test.js
+++ b/__tests__/ImageminPlugin.test.js
@@ -648,64 +648,6 @@ describe("imagemin plugin", () => {
     );
   });
 
-  it("should optimizes images and contains not empty manifest", async () => {
-    const manifest = {};
-    const stats = await webpack({
-      emitPlugin: true,
-      entry: path.join(fixturesPath, "single-image-loader.js"),
-      imageminPluginOptions: {
-        imageminOptions: {
-          plugins,
-        },
-        manifest,
-      },
-    });
-    const { compilation } = stats;
-    const { warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-
-    expect(manifest).toEqual({
-      "plugin-test.jpg": "f48748954547acf94595fa0b22e03be5.jpg",
-    });
-  });
-
-  it("should optimizes images and interpolate assets names exclude module assets", async () => {
-    const manifest = {};
-    const stats = await webpack({
-      emitPlugin: true,
-      entry: path.join(fixturesPath, "loader.js"),
-      imageminPluginOptions: {
-        imageminOptions: {
-          plugins,
-        },
-        loader: false,
-        manifest,
-      },
-    });
-    const { compilation } = stats;
-    const { assets, warnings, errors } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-    expect(
-      Object.keys(assets).every((element) =>
-        [
-          "loader-test.gif",
-          "loader-test.jpg",
-          "loader-test.png",
-          "loader-test.svg",
-          "bundle.js",
-          "f48748954547acf94595fa0b22e03be5.jpg",
-        ].includes(element)
-      )
-    ).toBe(true);
-    expect(manifest).toEqual({
-      "plugin-test.jpg": "f48748954547acf94595fa0b22e03be5.jpg",
-    });
-  });
-
   it("should optimizes all images (loader + plugin) and interpolate `[name].[ext]` name", async () => {
     const stats = await webpack({
       emitPluginOptions: {

--- a/__tests__/ImageminPlugin.test.js
+++ b/__tests__/ImageminPlugin.test.js
@@ -727,61 +727,6 @@ describe("imagemin plugin", () => {
     ).resolves.toBe(true);
   });
 
-  it("should optimizes all images (loader + plugin) and interpolate `dir/[path][name].sub.[ext]` name", async () => {
-    const stats = await webpack({
-      entry: path.join(fixturesPath, "./nested/deep/loader.js"),
-      emitPluginOptions: {
-        fileNames: ["nested/deep/plugin-test.png"],
-      },
-      imageminPluginOptions: {
-        imageminOptions: { plugins },
-        name: "dir/[path][name].sub.[ext]",
-      },
-      name: "dir/[path][name].sub.[ext]",
-    });
-    const { compilation } = stats;
-    const { warnings, errors, modules } = compilation;
-
-    expect(warnings).toHaveLength(0);
-    expect(errors).toHaveLength(0);
-
-    expect(hasLoader("loader-test.gif", modules)).toBe(true);
-    expect(hasLoader("loader-test.jpg", modules)).toBe(true);
-    expect(hasLoader("loader-test.gif", modules)).toBe(true);
-    expect(hasLoader("loader-test.svg", modules)).toBe(true);
-
-    await expect(
-      isOptimized(
-        ["dir/nested/deep/loader-test.sub.gif", "nested/deep/loader-test.gif"],
-        compilation
-      )
-    ).resolves.toBe(true);
-    await expect(
-      isOptimized(
-        ["dir/nested/deep/loader-test.sub.jpg", "nested/deep/loader-test.jpg"],
-        compilation
-      )
-    ).resolves.toBe(true);
-    await expect(
-      isOptimized(
-        ["dir/nested/deep/loader-test.sub.png", "nested/deep/loader-test.png"],
-        compilation
-      )
-    ).resolves.toBe(true);
-    await expect(
-      isOptimized(
-        ["dir/nested/deep/loader-test.sub.svg", "nested/deep/loader-test.svg"],
-        compilation
-      )
-    ).resolves.toBe(true);
-    await expect(
-      isOptimized(
-        ["dir/nested/deep/plugin-test.sub.png", "nested/deep/plugin-test.png"],
-        compilation
-      )
-    ).resolves.toBe(true);
-  });
-
   it("should optimizes all images (loader + plugin) exclude filtered", async () => {
     const stats = await webpack({
       emitPlugin: true,
@@ -856,7 +801,6 @@ describe("imagemin plugin", () => {
           imageminOptions: {
             plugins,
           },
-          name: "[name].1.[ext]",
         },
         {
           filter: (source) => {
@@ -871,7 +815,6 @@ describe("imagemin plugin", () => {
           imageminOptions: {
             plugins,
           },
-          name: "[name].2.[ext]",
         },
       ],
     });
@@ -894,16 +837,10 @@ describe("imagemin plugin", () => {
       isOptimized("multiple-loader-test-2.svg", compilation)
     ).resolves.toBe(true);
     await expect(
-      isOptimized(
-        ["multiple-plugin-test-1.1.svg", "multiple-plugin-test-1.svg"],
-        compilation
-      )
+      isOptimized("multiple-plugin-test-1.svg", compilation)
     ).resolves.toBe(true);
     await expect(
-      isOptimized(
-        ["multiple-plugin-test-2.2.svg", "multiple-plugin-test-2.svg"],
-        compilation
-      )
+      isOptimized("multiple-plugin-test-2.svg", compilation)
     ).resolves.toBe(true);
   });
 
@@ -933,7 +870,6 @@ describe("imagemin plugin", () => {
           imageminOptions: {
             plugins,
           },
-          name: "[name].1.[ext]",
         },
       },
       {
@@ -981,10 +917,7 @@ describe("imagemin plugin", () => {
       isOptimized("multiple-loader-test-2.svg", firstCompilation)
     ).resolves.toBe(false);
     await expect(
-      isOptimized(
-        ["multiple-plugin-test-1.1.svg", "multiple-plugin-test-1.svg"],
-        firstCompilation
-      )
+      isOptimized("multiple-plugin-test-1.svg", firstCompilation)
     ).resolves.toBe(true);
     await expect(
       isOptimized("multiple-plugin-test-2.svg", firstCompilation)
@@ -1015,10 +948,7 @@ describe("imagemin plugin", () => {
       isOptimized("multiple-plugin-test-3.svg", secondCompilation)
     ).resolves.toBe(false);
     await expect(
-      isOptimized(
-        ["multiple-plugin-test-4.2.svg", "multiple-plugin-test-4.svg"],
-        secondCompilation
-      )
+      isOptimized("multiple-plugin-test-4.svg", secondCompilation)
     ).resolves.toBe(true);
   });
 

--- a/__tests__/ImageminPlugin.test.js
+++ b/__tests__/ImageminPlugin.test.js
@@ -153,7 +153,6 @@ describe("imagemin plugin", () => {
       imageminPluginOptions: {
         cache: true,
         imageminOptions: { plugins },
-        name: "[path][name].[ext]",
       },
     };
     const stats = await webpack(options);
@@ -236,7 +235,6 @@ describe("imagemin plugin", () => {
       imageminPluginOptions: {
         cache: cacheDir,
         imageminOptions: { plugins },
-        name: "[path][name].[ext]",
       },
     };
     const stats = await webpack(options);
@@ -315,7 +313,6 @@ describe("imagemin plugin", () => {
       imageminPluginOptions: {
         cache: false,
         imageminOptions: { plugins },
-        name: "[path][name].[ext]",
       },
     });
 
@@ -354,7 +351,6 @@ describe("imagemin plugin", () => {
       imageminPluginOptions: {
         imageminOptions: { plugins },
         loader: false,
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -397,7 +393,6 @@ describe("imagemin plugin", () => {
       emitPlugin: true,
       entry: path.join(fixturesPath, "empty-entry.js"),
       imageminPluginOptions: {
-        name: "[name].[ext]",
         imageminOptions: {
           plugins: [],
         },
@@ -448,7 +443,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -473,7 +467,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -501,7 +494,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -526,7 +518,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -554,7 +545,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -579,7 +569,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -607,7 +596,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -655,9 +643,7 @@ describe("imagemin plugin", () => {
       },
       imageminPluginOptions: {
         imageminOptions: { plugins },
-        name: "[name].[ext]",
       },
-      name: "[name].[ext]",
     });
     const { compilation } = stats;
     const { warnings, errors, modules } = compilation;
@@ -695,9 +681,7 @@ describe("imagemin plugin", () => {
       },
       imageminPluginOptions: {
         imageminOptions: { plugins },
-        name: "[path][name].[ext]",
       },
-      name: "[path][name].[ext]",
     });
     const { compilation } = stats;
     const { warnings, errors, modules } = compilation;
@@ -747,7 +731,6 @@ describe("imagemin plugin", () => {
         imageminOptions: {
           plugins,
         },
-        name: "[path][name].[ext]",
       },
     });
     const { compilation } = stats;
@@ -893,7 +876,6 @@ describe("imagemin plugin", () => {
           imageminOptions: {
             plugins,
           },
-          name: "[name].2.[ext]",
         },
       },
     ]);

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -101,7 +101,6 @@ function runWebpack(maybeOptions) {
                 imageminOptions: {
                   plugins,
                 },
-                name: "[path][name].[ext]",
               }
             : imageminPluginOptions
         );

--- a/src/ImageminPlugin.js
+++ b/src/ImageminPlugin.js
@@ -21,7 +21,6 @@ class ImageminPlugin {
         plugins: [],
       },
       loader = true,
-      manifest,
       maxConcurrency,
       name = "[hash].[ext]",
     } = options;
@@ -34,7 +33,6 @@ class ImageminPlugin {
       imageminOptions,
       include,
       loader,
-      manifest,
       maxConcurrency,
       name,
       test,
@@ -118,7 +116,6 @@ class ImageminPlugin {
         filter,
         imageminOptions,
         maxConcurrency,
-        manifest,
         name,
       } = this.options;
 
@@ -194,10 +191,6 @@ class ImageminPlugin {
 
         if (interpolatedName !== originalResourcePath) {
           delete compilation.assets[originalResourcePath];
-        }
-
-        if (manifest && !manifest[originalResourcePath]) {
-          manifest[originalResourcePath] = interpolatedName;
         }
       });
 

--- a/src/ImageminPlugin.js
+++ b/src/ImageminPlugin.js
@@ -4,7 +4,6 @@ const path = require("path");
 const webpack = require("webpack");
 const RawSource = require("webpack-sources/lib/RawSource");
 const ModuleFilenameHelpers = require("webpack/lib/ModuleFilenameHelpers");
-const loaderUtils = require("loader-utils");
 
 const minify = require("./minify");
 
@@ -22,7 +21,6 @@ class ImageminPlugin {
       },
       loader = true,
       maxConcurrency,
-      name = "[hash].[ext]",
     } = options;
 
     this.options = {
@@ -34,7 +32,6 @@ class ImageminPlugin {
       include,
       loader,
       maxConcurrency,
-      name,
       test,
     };
   }
@@ -116,7 +113,6 @@ class ImageminPlugin {
         filter,
         imageminOptions,
         maxConcurrency,
-        name,
       } = this.options;
 
       Object.keys(assets).forEach((file) => {
@@ -181,17 +177,7 @@ class ImageminPlugin {
           return;
         }
 
-        const interpolatedName = loaderUtils.interpolateName(
-          { resourcePath: path.join(context, originalResourcePath) },
-          name,
-          { content: source.source(), context }
-        );
-
-        compilation.assets[interpolatedName] = source;
-
-        if (interpolatedName !== originalResourcePath) {
-          delete compilation.assets[originalResourcePath];
-        }
+        compilation.assets[originalResourcePath] = source;
       });
 
       return Promise.resolve();

--- a/src/ImageminPlugin.js
+++ b/src/ImageminPlugin.js
@@ -177,7 +177,7 @@ class ImageminPlugin {
           return;
         }
 
-        compilation.assets[originalResourcePath] = source;
+        compilation.assets[originalResourcePath.replace(/\\/g, "/")] = source;
       });
 
       return Promise.resolve();
@@ -203,9 +203,5 @@ class ImageminPlugin {
     }
   }
 }
-
-//------------------------------------------------------------------------------
-// Public API
-//------------------------------------------------------------------------------
 
 module.exports = ImageminPlugin;


### PR DESCRIPTION
Remove `name` and `manifest` option, we don't need them, because we don't change name of assets anymore, if you need to change name you can achieve this using the `name` option of `file-loader`, using the `to` option of pattern of `copy-webpack-plugin` (https://github.com/webpack-contrib/copy-webpack-plugin#to), or using other own plugin, changing name is out of scope is plugin and will be mistake in design